### PR TITLE
fix: 配置文件中导入 xxx.list 文件造成捕获的快照体积巨大问题

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -167,7 +167,10 @@ func ReadFileInclude(f string) []string {
 	for _, l := range strings.Split(string(bs), "\n") {
 		l = strings.TrimSpace(l)
 		if l != "" {
-			ret = append(ret, l)
+			fileInfo, err := os.Stat(l)
+			if err == nil && !fileInfo.IsDir() {
+				ret = append(ret, l)
+			}
 		}
 	}
 	return ret


### PR DESCRIPTION
Bug: https://pms.uniontech.com/bug-view-172109.html
Log: 修复配置文件中导入 xxx.list 文件造成捕获的快照体积巨大问题
Influence: 自动快照抓取