### PR TITLE
fix: 被损坏的snapshot 文件未及时删除

### DIFF
--- a/daemon/history.go
+++ b/daemon/history.go
@@ -197,11 +197,20 @@ func (h *History) getSnapSize(id string) int {
 }
 
 func (h *History) doApply(id string) error {
+	snapPath := h.path(id)
 	var snap core.Snapshot
-	err := core.LoadFrom(h.path(id), &snap)
+	err := core.LoadFrom(snapPath, &snap)
 	if err != nil {
+		// 如果加载失败，表示 snap 文件已损坏，应该删除
+		Log("remove the corrupted snapshot file %s", snapPath)
+		rmErr := os.Remove(snapPath)
+		if rmErr != nil {
+			Log("WARN: remove the corrupted snapshot file failed: %v\n", err)
+		}
+
 		return err
 	}
+
 	err = core.ApplySnapshot(&snap, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
删除之后，下次重启才能重新抓取。

Log: 改进对被损坏的 snapshot 文件处理
Task: https://pms.uniontech.com/task-view-219315.html