### PR TITLE
fix: 如果捕获快照失败了没有重试

### DIFF
--- a/daemon/schedule.go
+++ b/daemon/schedule.go
@@ -24,7 +24,10 @@ func (d *Daemon) scheduleApplys() error {
 		if len(afters) == 0 {
 			err = d.history.RequestApply(name, initUsage)
 		} else {
-			err = events.Connect(afters, func() { d.history.RequestApply(name, initUsage) })
+			err = events.Connect(afters, func() bool {
+				d.history.RequestApply(name, initUsage)
+				return false
+			})
 		}
 		if err != nil {
 			return err
@@ -50,8 +53,12 @@ func (d *Daemon) scheduleCaptures() error {
 		if len(afters) == 0 {
 			err = d.history.DoCapture(id, capture, mtime)
 		} else {
-			err = events.Connect(afters, func() {
-				d.history.DoCapture(id, capture, mtime)
+			err = events.Connect(afters, func() bool {
+				capErr := d.history.DoCapture(id, capture, mtime)
+				if capErr != nil {
+					return d.retryCapture(id, &capture)
+				}
+				return false
 			})
 		}
 		if err != nil {
@@ -59,6 +66,40 @@ func (d *Daemon) scheduleCaptures() error {
 		}
 	}
 	return nil
+}
+
+func (d *Daemon) recordCaptureRetry(id string) (can bool) {
+	const retryLimit = 30
+
+	d.retryCaptureMu.Lock()
+	defer d.retryCaptureMu.Unlock()
+
+	d.retryCaptureCount[id]++
+	count := d.retryCaptureCount[id]
+	return count < retryLimit
+}
+
+func (d *Daemon) retryCapture(id string, captureCfg *CaptureConfig) (noDel bool) {
+	// 仅能重试 After 含有 x11 scope 事件的捕获
+	hasX11 := false
+	for _, event := range captureCfg.After {
+		scope, _, ok := events.SplitEvent(event)
+		if ok && scope == "x11" {
+			hasX11 = true
+		}
+	}
+	if !hasX11 {
+		return false
+	}
+
+	if !d.recordCaptureRetry(id) {
+		Log("retries to capture %v have reached the limit\n", id)
+		return false
+	}
+
+	// 可以重试
+	Log("retry capture %v\n", id)
+	return true
 }
 
 func (d *Daemon) Schedule(ctx context.Context) error {

--- a/events/event_test.go
+++ b/events/event_test.go
@@ -78,8 +78,9 @@ func TestWait(t *testing.T) {
 
 func TestProcess(t *testing.T) {
 	found := false
-	Connect([]string{"process:go"}, func() {
+	Connect([]string{"process:go"}, func() bool {
 		found = true
+		return false
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -95,13 +96,15 @@ func TestProcess(t *testing.T) {
 }
 
 func TestFile(t *testing.T) {
-	Connect([]string{"file:/shouldn't have this file"}, func() {
+	Connect([]string{"file:/shouldn't have this file"}, func() bool {
 		t.Fatal("The file shouldn't exists.")
+		return false
 	})
 
 	found := false
-	Connect([]string{"file:/etc"}, func() {
+	Connect([]string{"file:/etc"}, func() bool {
 		found = true
+		return false
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()


### PR DESCRIPTION
修改为如果捕获失败后，x11 scope 的事件再次发生可以重新触发生成快照。

Log: 改进对于捕获快照失败的处理
Task: https://pms.uniontech.com/task-view-219315.html