### PR TITLE
fix: mincores 内核模块不能用于 btrfs 文件系统

### DIFF
--- a/kernel/mincores.c
+++ b/kernel/mincores.c
@@ -35,11 +35,23 @@ static inline int radix_tree_exceptional_entry(void *arg)
 
 static bool is_normal_fs_type(struct super_block* sb)
 {
-    const char* typ = 0;
-    if (sb == 0 || sb->s_bdev == 0) {
+    const char* typ = NULL;
+    if (sb == NULL)
+    {
         return false;
     }
+
     typ = sb->s_type->name;
+    if (strcmp(typ, "btrfs") == 0) {
+        // NOTE: btrfs 不判断 sb->s_bdev
+        return true;
+    }
+
+    if (sb->s_bdev == NULL)
+    {
+        return false;
+    }
+
     if (strcmp(typ, "ext3") == 0||
         strcmp(typ, "ext4") == 0||
         strcmp(typ, "ext2") == 0||


### PR DESCRIPTION
对于 btrfs 文件系统，条件 sb->s_bdev == 0 判断是 true

Log: 修复 mincores 内核模块不能用于 btrfs 文件系统的问题